### PR TITLE
Guard Cloud Run deploy job when WIF secrets unavailable

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -47,7 +47,11 @@ jobs:
   build-and-deploy:
     needs: test
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: |
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main' &&
+      secrets.WIF_PROVIDER != '' &&
+      secrets.WIF_SERVICE_ACCOUNT != ''
     
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- ensure the deploy job only runs when Workload Identity secrets are present to avoid auth failures on forked workflows

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd767e6d0c8331a5603d813fc487b4