### PR TITLE
Scaffold Rust core workspace with multi-surface APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,7 @@ npm-debug.log*
 
 # Data files
 data/
+!rust/core/src/data/
 experiments/
 results/
 *.hdf5

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,21 @@
+set shell := ["bash", "-cu"]
+
+setup:
+curl https://sh.rustup.rs -sSf | sh -s -- -y
+rustup target add wasm32-unknown-unknown
+cargo install cargo-watch cargo-audit cargo-deny maturin wasm-bindgen-cli wasm-pack --locked
+
+run:
+cd rust && cargo run -p service
+
+test:
+cd rust && cargo test --all --all-features
+
+pywheel:
+cd rust/pycore && maturin build --release
+
+wasm:
+cd rust/wasm-demo && wasm-pack build --target web --out-dir pkg
+
+service:
+cd rust/service && cargo run

--- a/configs/service.yaml
+++ b/configs/service.yaml
@@ -1,0 +1,8 @@
+http:
+  addr: 0.0.0.0:8080
+grpc:
+  addr: 0.0.0.0:50051
+telemetry:
+  otlp_endpoint: null
+database:
+  url: null

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,0 +1,76 @@
+[workspace]
+members = [
+    "core",
+    "service",
+    "pycore",
+    "wasm-demo",
+]
+resolver = "2"
+
+[workspace.package]
+edition = "2021"
+license = "Apache-2.0"
+version = "0.1.0"
+authors = ["Autonomous R&D Intelligence Layer Team"]
+
+[workspace.metadata]
+cargo-lock = true
+
+[workspace.dependencies]
+anyhow = "1"
+async-trait = "0.1"
+chrono = { version = "0.4", features = ["serde", "clock"] }
+futures = "0.3"
+indexmap = { version = "2", features = ["serde"] }
+itertools = "0.12"
+ndarray = { version = "0.15", features = ["serde"] }
+once_cell = "1"
+parking_lot = "0.12"
+rand = "0.8"
+rand_chacha = "0.3"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+serde_yaml = "0.9"
+serde_with = "3"
+thiserror = "1"
+tracing = "0.1"
+tracing-appender = "0.2"
+tracing-error = "0.2"
+tracing-futures = "0.2"
+tracing-opentelemetry = "0.22"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json", "registry"] }
+uuid = { version = "1", features = ["v4", "serde"] }
+proptest = "1"
+# service
+axum = { version = "0.7", features = ["macros", "json"] }
+axum-extra = { version = "0.9", features = ["typed-header"] }
+clap = { version = "4", features = ["derive", "env"] }
+config = { version = "0.14", features = ["yaml"] }
+hyper = { version = "1", features = ["server", "http1", "http2"] }
+opentelemetry = { version = "0.21", features = ["rt-tokio"] }
+opentelemetry-otlp = { version = "0.14", features = ["http-proto", "tls"] }
+opentelemetry-prometheus = "0.14"
+opentelemetry-stdout = "0.3"
+prometheus = "0.13"
+secrecy = "0.8"
+sqlx = { version = "0.7", default-features = false, features = ["runtime-tokio", "macros", "uuid", "chrono"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal"] }
+tokio-stream = "0.1"
+tokio-util = "0.7"
+tonic = { version = "0.11", features = ["transport"] }
+tower = { version = "0.4", features = ["util", "timeout"] }
+tower-http = { version = "0.5", features = ["trace", "cors"] }
+prost = "0.12"
+prost-types = "0.12"
+utoipa = { version = "4", features = ["axum_extras", "uuid", "time"] }
+utoipa-swagger-ui = { version = "7", features = ["axum"] }
+
+# python bindings
+pyo3 = { version = "0.21", features = ["extension-module", "abi3", "abi3-py39"] }
+
+# wasm
+wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
+wasm-bindgen-futures = "0.4"
+js-sys = "0.3"
+web-sys = { version = "0.3", features = ["console"] }
+getrandom = { version = "0.2", features = ["js"] }

--- a/rust/core/Cargo.toml
+++ b/rust/core/Cargo.toml
@@ -1,0 +1,52 @@
+[package]
+name = "core"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+
+[lib]
+name = "periodic_core"
+
+[features]
+default = ["std"]
+std = []
+arrow = ["dep:arrow", "dep:arrow-array", "dep:arrow-ipc", "dep:arrow-schema", "dep:parquet"]
+polars = ["dep:polars"]
+instrument_control = []
+gpu = []
+wasm = []
+pybind = []
+postgres = []
+
+[dependencies]
+anyhow.workspace = true
+async-trait.workspace = true
+indexmap.workspace = true
+itertools.workspace = true
+ndarray.workspace = true
+once_cell.workspace = true
+parking_lot.workspace = true
+rand.workspace = true
+rand_chacha.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+serde_yaml.workspace = true
+serde_with.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+tracing-error.workspace = true
+tracing-futures.workspace = true
+uuid.workspace = true
+chrono.workspace = true
+proptest.workspace = true
+arrow = { version = "53", optional = true }
+arrow-array = { version = "53", optional = true }
+arrow-ipc = { version = "53", optional = true }
+arrow-schema = { version = "53", optional = true }
+parquet = { version = "53", optional = true }
+polars = { version = "0.42", optional = true, features = ["lazy", "parquet"] }
+
+[dev-dependencies]
+proptest.workspace = true
+serde_json.workspace = true
+tracing.workspace = true

--- a/rust/core/fuzz/Cargo.toml
+++ b/rust/core/fuzz/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "core-fuzz"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+libfuzzer-sys = "0.4"
+periodic_core = { path = ".." }
+
+[[bin]]
+name = "plan_trace"
+path = "fuzz_targets/plan_trace.rs"
+
+[[bin]]
+name = "objective_parser"
+path = "fuzz_targets/objective_parser.rs"

--- a/rust/core/fuzz/fuzz_targets/objective_parser.rs
+++ b/rust/core/fuzz/fuzz_targets/objective_parser.rs
@@ -1,0 +1,18 @@
+#![no_main]
+use indexmap::IndexMap;
+use libfuzzer_sys::fuzz_target;
+use periodic_core::Objective;
+
+fuzz_target!(|data: &[u8]| {
+    if data.is_empty() {
+        return;
+    }
+    let description = String::from_utf8_lossy(data).into_owned();
+    let mut metrics = IndexMap::new();
+    metrics.insert("yield".to_string(), (data[0] as f64) / 255.0);
+    let objective = Objective {
+        description,
+        target_metrics: metrics,
+    };
+    assert!(!objective.description.is_empty());
+});

--- a/rust/core/fuzz/fuzz_targets/plan_trace.rs
+++ b/rust/core/fuzz/fuzz_targets/plan_trace.rs
@@ -1,0 +1,26 @@
+#![no_main]
+use indexmap::IndexMap;
+use libfuzzer_sys::fuzz_target;
+use periodic_core::{plan::planner::DeterministicPlanner, Objective};
+use rand::{rngs::StdRng, SeedableRng};
+
+fuzz_target!(|data: &[u8]| {
+    if data.len() < 4 {
+        return;
+    }
+    let seed = u64::from_le_bytes({
+        let mut bytes = [0u8; 8];
+        for (i, b) in data.iter().take(8).enumerate() {
+            bytes[i] = *b;
+        }
+        bytes
+    });
+    let mut metrics = IndexMap::new();
+    metrics.insert("yield".to_string(), (data[0] as f64) / 255.0);
+    let planner = DeterministicPlanner::new(StdRng::seed_from_u64(seed));
+    let objective = Objective {
+        description: format!("fuzz-{}", data.len()),
+        target_metrics: metrics,
+    };
+    let _ = planner.plan(objective);
+});

--- a/rust/core/src/data/arrow_io.rs
+++ b/rust/core/src/data/arrow_io.rs
@@ -1,0 +1,59 @@
+#![cfg(feature = "arrow")]
+
+use arrow::array::{Float64Array, StringArray, StructArray};
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+use arrow_ipc::writer::FileWriter;
+use std::io::Write;
+
+use crate::{Plan, RationaleTraceEntry};
+
+pub fn plan_to_record_batch(plan: &Plan) -> RecordBatch {
+    let option = StringArray::from(
+        plan.rationale_trace
+            .iter()
+            .map(|entry| entry.option.clone())
+            .collect::<Vec<_>>(),
+    );
+    let score = Float64Array::from(
+        plan.rationale_trace
+            .iter()
+            .map(|entry| entry.score)
+            .collect::<Vec<_>>(),
+    );
+    let why = StringArray::from(
+        plan.rationale_trace
+            .iter()
+            .map(|entry| entry.why.clone())
+            .collect::<Vec<_>>(),
+    );
+    let struct_array = StructArray::from(vec![
+        (
+            Field::new("option", DataType::Utf8, false),
+            Arc::new(option) as _,
+        ),
+        (
+            Field::new("score", DataType::Float64, false),
+            Arc::new(score) as _,
+        ),
+        (Field::new("why", DataType::Utf8, false), Arc::new(why) as _),
+    ]);
+    RecordBatch::try_new(
+        Arc::new(Schema::new(vec![Field::new(
+            "rationale",
+            DataType::Struct(struct_array.fields().to_vec()),
+            false,
+        )])),
+        vec![Arc::new(struct_array)],
+    )
+    .expect("valid batch")
+}
+
+pub fn write_plan<W: Write>(plan: &Plan, writer: W) {
+    let batch = plan_to_record_batch(plan);
+    let mut writer = FileWriter::try_new(writer, batch.schema()).expect("writer");
+    writer.write(&batch).expect("write batch");
+    writer.finish().expect("finish writer");
+}
+
+use std::sync::Arc;

--- a/rust/core/src/data/mod.rs
+++ b/rust/core/src/data/mod.rs
@@ -1,0 +1,2 @@
+#[cfg(feature = "arrow")]
+pub mod arrow_io;

--- a/rust/core/src/errors.rs
+++ b/rust/core/src/errors.rs
@@ -1,0 +1,13 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum CoreError {
+    #[error("invalid objective: {0}")]
+    InvalidObjective(String),
+    #[error("planning failure: {0}")]
+    PlanningFailure(String),
+    #[error("data access failure: {0}")]
+    DataAccess(String),
+}
+
+pub type CoreResult<T> = Result<T, CoreError>;

--- a/rust/core/src/features.rs
+++ b/rust/core/src/features.rs
@@ -1,0 +1,12 @@
+pub fn enabled(name: &str) -> bool {
+    match name {
+        "instrument_control" => cfg!(feature = "instrument_control"),
+        "gpu" => cfg!(feature = "gpu"),
+        "wasm" => cfg!(feature = "wasm"),
+        "pybind" => cfg!(feature = "pybind"),
+        "postgres" => cfg!(feature = "postgres"),
+        "arrow" => cfg!(feature = "arrow"),
+        "polars" => cfg!(feature = "polars"),
+        _ => false,
+    }
+}

--- a/rust/core/src/lib.rs
+++ b/rust/core/src/lib.rs
@@ -1,0 +1,134 @@
+#![deny(clippy::all)]
+
+pub mod data;
+pub mod errors;
+pub mod features;
+pub mod plan;
+pub mod qc;
+pub mod tracing;
+
+use chrono::{DateTime, Utc};
+use plan::planner::{DeterministicPlanner, Planner};
+use rand::{rngs::StdRng, SeedableRng};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use tracing::info_span;
+use uuid::Uuid;
+
+/// Unique identifier type alias for domain objects.
+pub type Id = Uuid;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Sample {
+    pub id: Id,
+    pub composition: IndexMap<String, f64>,
+    pub provenance: String,
+    pub batch: String,
+}
+
+use indexmap::IndexMap;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Constraint {
+    pub name: String,
+    pub description: String,
+    pub satisfied: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Step {
+    pub description: String,
+    pub duration_minutes: u32,
+    pub rationale: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Recipe {
+    pub steps: Vec<Step>,
+    pub constraints: Vec<Constraint>,
+    pub safety_interlocks: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RationaleTraceEntry {
+    pub option: String,
+    pub score: f64,
+    pub why: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Plan {
+    pub id: Id,
+    pub objective: Objective,
+    pub candidate_recipes: Vec<Recipe>,
+    pub rationale_trace: Vec<RationaleTraceEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Run {
+    pub id: Id,
+    pub instrument_id: String,
+    pub params: IndexMap<String, String>,
+    pub started_at: DateTime<Utc>,
+    pub finished_at: Option<DateTime<Utc>>,
+    pub artifacts: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct QCCheck {
+    pub id: Id,
+    pub checklist_items: Vec<String>,
+    pub outcome: QCOutcome,
+    pub notes: String,
+    pub negatives_captured: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum QCOutcome {
+    Pass,
+    Fail,
+    NeedsReview,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Objective {
+    pub description: String,
+    pub target_metrics: IndexMap<String, f64>,
+}
+
+/// High-level façade for the core planner that binds deterministic seeding with telemetry.
+#[derive(Clone)]
+pub struct CorePlanner {
+    planner: Arc<DeterministicPlanner>,
+}
+
+impl CorePlanner {
+    pub fn new(seed: u64) -> Self {
+        let rng = StdRng::seed_from_u64(seed);
+        Self {
+            planner: Arc::new(DeterministicPlanner::new(rng)),
+        }
+    }
+
+    pub fn plan(&self, objective: Objective) -> Result<Plan, errors::CoreError> {
+        let span = info_span!("plan.generate", objective = %objective.description);
+        let _guard = span.enter();
+        self.planner.plan(objective)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plan_contains_rationale() {
+        let planner = CorePlanner::new(42);
+        let objective = Objective {
+            description: "Test objective".to_string(),
+            target_metrics: IndexMap::from([(String::from("yield"), 0.9)]),
+        };
+        let plan = planner.plan(objective).expect("plan generation succeeds");
+        assert!(!plan.rationale_trace.is_empty());
+    }
+}

--- a/rust/core/src/plan/mod.rs
+++ b/rust/core/src/plan/mod.rs
@@ -1,0 +1,1 @@
+pub mod planner;

--- a/rust/core/src/plan/planner.rs
+++ b/rust/core/src/plan/planner.rs
@@ -1,0 +1,77 @@
+use crate::{errors::CoreError, Objective, Plan, RationaleTraceEntry, Recipe, Step};
+use itertools::Itertools;
+use parking_lot::Mutex;
+use rand::{rngs::StdRng, Rng};
+use tracing::info_span;
+use uuid::Uuid;
+
+pub trait Planner: Send + Sync {
+    fn plan(&self, objective: Objective) -> Result<Plan, CoreError>;
+}
+
+#[derive(Debug)]
+pub struct DeterministicPlanner {
+    rng: Mutex<StdRng>,
+}
+
+impl DeterministicPlanner {
+    pub fn new(rng: StdRng) -> Self {
+        Self {
+            rng: parking_lot::Mutex::new(rng),
+        }
+    }
+
+    fn score_options(&self, objective: &Objective) -> Vec<RationaleTraceEntry> {
+        let mut rng = self.rng.lock();
+        let mut entries = objective
+            .target_metrics
+            .iter()
+            .map(|(metric, target)| {
+                let jitter: f64 = rng.gen::<f64>() / 10.0;
+                let score = target + jitter;
+                RationaleTraceEntry {
+                    option: format!("Optimize {metric}"),
+                    score,
+                    why: format!("Target {target:.3} + jitter {jitter:.3}"),
+                }
+            })
+            .collect_vec();
+        entries.sort_by(|a, b| b.score.total_cmp(&a.score));
+        entries
+    }
+
+    fn synthesize_recipe(entry: &RationaleTraceEntry) -> Recipe {
+        let step = Step {
+            description: format!("Adjust parameter for {}", entry.option),
+            duration_minutes: 15,
+            rationale: entry.why.clone(),
+        };
+        Recipe {
+            steps: vec![step],
+            constraints: vec![crate::Constraint {
+                name: "safety-window".to_string(),
+                description: "Operate within validated bounds".to_string(),
+                satisfied: true,
+            }],
+            safety_interlocks: vec!["interlock-1".to_string()],
+        }
+    }
+}
+
+impl Planner for DeterministicPlanner {
+    fn plan(&self, objective: Objective) -> Result<Plan, CoreError> {
+        let span = info_span!("planner.evaluate", objective = %objective.description);
+        let _guard = span.enter();
+        if objective.target_metrics.is_empty() {
+            return Err(CoreError::InvalidObjective("missing target metrics".into()));
+        }
+        let rationale = self.score_options(&objective);
+        let candidate_recipes = rationale.iter().map(Self::synthesize_recipe).collect();
+        Ok(Plan {
+            id: Uuid::new_v4(),
+            objective,
+            candidate_recipes,
+            rationale_trace: rationale,
+        })
+    }
+}

--- a/rust/core/src/qc/checklist.rs
+++ b/rust/core/src/qc/checklist.rs
@@ -1,0 +1,58 @@
+use crate::{errors::CoreError, QCCheck, QCOutcome};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ChecklistItem {
+    pub description: String,
+    pub required: bool,
+    pub satisfied: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Checklist {
+    pub id: Uuid,
+    pub name: String,
+    pub items: Vec<ChecklistItem>,
+}
+
+impl Checklist {
+    pub fn run(
+        self,
+        notes: impl Into<String>,
+        negatives: Vec<String>,
+    ) -> Result<QCCheck, CoreError> {
+        let outcome = if self.items.iter().all(|item| item.satisfied) {
+            QCOutcome::Pass
+        } else if self
+            .items
+            .iter()
+            .any(|item| item.required && !item.satisfied)
+        {
+            QCOutcome::Fail
+        } else {
+            QCOutcome::NeedsReview
+        };
+        Ok(QCCheck {
+            id: self.id,
+            checklist_items: self
+                .items
+                .iter()
+                .map(|item| {
+                    format!(
+                        "{} - {}",
+                        item.description,
+                        if item.satisfied {
+                            "ok"
+                        } else {
+                            "needs attention"
+                        }
+                    )
+                })
+                .collect(),
+            outcome,
+            notes: notes.into(),
+            negatives_captured: negatives,
+        })
+    }
+}

--- a/rust/core/src/qc/mod.rs
+++ b/rust/core/src/qc/mod.rs
@@ -1,0 +1,1 @@
+pub mod checklist;

--- a/rust/core/src/tracing.rs
+++ b/rust/core/src/tracing.rs
@@ -1,0 +1,19 @@
+use once_cell::sync::OnceCell;
+use tracing::Subscriber;
+use tracing_subscriber::{fmt, layer::SubscriberExt, EnvFilter, Registry};
+
+static TRACING: OnceCell<()> = OnceCell::new();
+
+pub fn init_tracing() {
+    TRACING.get_or_init(|| {
+        let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+        let fmt_layer = fmt::layer().with_target(false).with_ansi(false);
+        let subscriber = Registry::default().with(filter).with(fmt_layer);
+        tracing::subscriber::set_global_default(subscriber).expect("set global subscriber");
+    });
+}
+
+pub fn subscriber() -> impl Subscriber {
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    Registry::default().with(filter).with(fmt::layer())
+}

--- a/rust/core/tests/plan_props.rs
+++ b/rust/core/tests/plan_props.rs
@@ -1,0 +1,16 @@
+use indexmap::IndexMap;
+use periodic_core::{plan::planner::DeterministicPlanner, Objective};
+use proptest::prelude::*;
+use rand::{rngs::StdRng, SeedableRng};
+
+proptest! {
+    #[test]
+    fn rationale_is_never_empty(description in "[a-zA-Z0-9 ]{1,16}") {
+        let mut metrics = IndexMap::new();
+        metrics.insert("yield".to_string(), 0.8);
+        let planner = DeterministicPlanner::new(StdRng::seed_from_u64(1));
+        let objective = Objective { description, target_metrics: metrics };
+        let plan = planner.plan(objective).expect("plan");
+        prop_assert!(!plan.rationale_trace.is_empty());
+    }
+}

--- a/rust/pycore/Cargo.toml
+++ b/rust/pycore/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "pycore"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+
+[lib]
+name = "pycore"
+crate-type = ["cdylib"]
+
+[features]
+default = ["pybind"]
+pybind = []
+
+[dependencies]
+periodic_core = { path = "../core", package = "core", features = ["pybind"] }
+pyo3.workspace = true
+serde_json.workspace = true
+indexmap.workspace = true
+uuid.workspace = true

--- a/rust/pycore/Dockerfile
+++ b/rust/pycore/Dockerfile
@@ -1,0 +1,4 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY ../../rust ./
+RUN pip install maturin && maturin build --release -m pycore/pyproject.toml

--- a/rust/pycore/README.md
+++ b/rust/pycore/README.md
@@ -1,0 +1,29 @@
+# periodic-pycore
+
+Python bindings for the Periodic core planner built with [maturin](https://github.com/PyO3/maturin).
+
+## Build
+
+```bash
+just pywheel
+```
+
+or manually:
+
+```bash
+cd rust/pycore
+maturin build --release
+```
+
+## Usage
+
+```python
+from pycore import plan
+result = plan({
+    "description": "Improve catalyst throughput",
+    "metrics": [
+        {"name": "yield", "target": 0.9},
+    ],
+})
+print(result)
+```

--- a/rust/pycore/pyproject.toml
+++ b/rust/pycore/pyproject.toml
@@ -1,0 +1,19 @@
+[build-system]
+requires = ["maturin>=1,<2"]
+build-backend = "maturin"
+
+[project]
+name = "periodic-pycore"
+version = "0.1.0"
+description = "Python bindings for the Periodic core planner"
+authors = [{name = "Autonomous R&D Intelligence Layer Team"}]
+requires-python = ">=3.9"
+classifiers = [
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Rust",
+]
+
+[tool.maturin]
+bindings = "pyo3"
+features = ["pybind"]

--- a/rust/pycore/src/lib.rs
+++ b/rust/pycore/src/lib.rs
@@ -1,0 +1,58 @@
+use indexmap::IndexMap;
+use periodic_core::{CorePlanner, Objective};
+use pyo3::prelude::*;
+use std::sync::OnceLock;
+use uuid::Uuid;
+
+static PLANNER: OnceLock<CorePlanner> = OnceLock::new();
+
+fn planner() -> &'static CorePlanner {
+    PLANNER.get_or_init(|| CorePlanner::new(1337))
+}
+
+#[pyfunction]
+fn plan(objective: &PyAny) -> PyResult<PyObject> {
+    let description: String = objective.get_item("description")?.extract()?;
+    let metrics_py = objective.get_item("metrics")?;
+    let mut metrics = IndexMap::new();
+    for item in metrics_py.iter()? {
+        let item = item?;
+        let name: String = item.get_item("name")?.extract()?;
+        let target: f64 = item.get_item("target")?.extract()?;
+        metrics.insert(name, target);
+    }
+    let plan = planner()
+        .plan(Objective {
+            description,
+            target_metrics: metrics,
+        })
+        .map_err(|err| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(err.to_string()))?;
+    Python::with_gil(|py| Ok(serde_json::to_value(&plan)?.into_py(py)))
+}
+
+#[pyfunction]
+fn qc_check(items: Vec<String>, notes: Option<String>) -> PyResult<PyObject> {
+    let checklist = periodic_core::qc::checklist::Checklist {
+        id: Uuid::new_v4(),
+        name: "pycore".into(),
+        items: items
+            .into_iter()
+            .map(|item| periodic_core::qc::checklist::ChecklistItem {
+                description: item,
+                required: true,
+                satisfied: true,
+            })
+            .collect(),
+    };
+    let qc = checklist
+        .run(notes.unwrap_or_default(), vec![])
+        .map_err(|err| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(err.to_string()))?;
+    Python::with_gil(|py| Ok(serde_json::to_value(&qc)?.into_py(py)))
+}
+
+#[pymodule]
+fn pycore(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(plan, m)?)?;
+    m.add_function(wrap_pyfunction!(qc_check, m)?)?;
+    Ok(())
+}

--- a/rust/service/Cargo.toml
+++ b/rust/service/Cargo.toml
@@ -1,0 +1,64 @@
+[package]
+name = "service"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+
+[[bin]]
+name = "service"
+path = "src/main.rs"
+
+[lib]
+name = "service"
+path = "src/lib.rs"
+
+[features]
+default = []
+postgres = ["periodic_core/postgres"]
+
+[dependencies]
+anyhow.workspace = true
+axum.workspace = true
+axum-extra.workspace = true
+chrono.workspace = true
+clap.workspace = true
+config.workspace = true
+futures.workspace = true
+hyper.workspace = true
+once_cell.workspace = true
+opentelemetry.workspace = true
+opentelemetry-otlp.workspace = true
+opentelemetry-prometheus.workspace = true
+opentelemetry-stdout.workspace = true
+periodic_core = { path = "../core", package = "core" }
+prometheus.workspace = true
+prost.workspace = true
+prost-types.workspace = true
+secrecy.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+sqlx.workspace = true
+tokio.workspace = true
+tokio-stream.workspace = true
+tokio-util.workspace = true
+tonic.workspace = true
+tower.workspace = true
+tower-http.workspace = true
+tracing.workspace = true
+tracing-appender.workspace = true
+tracing-opentelemetry.workspace = true
+tracing-subscriber.workspace = true
+utoipa.workspace = true
+utoipa-swagger-ui.workspace = true
+uuid.workspace = true
+
+[build-dependencies]
+prost-build = "0.12"
+tonic-build = "0.11"
+
+[dev-dependencies]
+periodic_core = { path = "../core", package = "core" }
+reqwest = { version = "0.12", features = ["json"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tonic = { version = "0.11", features = ["transport"] }
+serde_json.workspace = true

--- a/rust/service/Dockerfile
+++ b/rust/service/Dockerfile
@@ -1,0 +1,10 @@
+FROM rust:1.80 as builder
+WORKDIR /app
+COPY ../../rust ./
+RUN cargo build --release -p service
+
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /app/target/release/service /usr/local/bin/service
+EXPOSE 8080 50051
+CMD ["/usr/local/bin/service"]

--- a/rust/service/build.rs
+++ b/rust/service/build.rs
@@ -1,0 +1,9 @@
+fn main() {
+    let proto_dir = std::path::Path::new("proto");
+    tonic_build::configure()
+        .build_server(true)
+        .compile_well_known_types(true)
+        .out_dir(std::env::var("OUT_DIR").unwrap())
+        .compile(&["proto/periodic/experiment.proto"], &[proto_dir])
+        .expect("compile protos");
+}

--- a/rust/service/openapi/periodic.openapi.json
+++ b/rust/service/openapi/periodic.openapi.json
@@ -1,0 +1,19 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Periodic Experiment Service",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/v1/plan": {
+      "post": {
+        "summary": "Generate a plan",
+        "responses": {
+          "200": {
+            "description": "Plan generated"
+          }
+        }
+      }
+    }
+  }
+}

--- a/rust/service/proto/periodic/experiment.proto
+++ b/rust/service/proto/periodic/experiment.proto
@@ -1,0 +1,56 @@
+syntax = "proto3";
+package periodic;
+
+message ObjectiveMetric {
+  string name = 1;
+  double target = 2;
+}
+
+message Objective {
+  string description = 1;
+  repeated ObjectiveMetric metrics = 2;
+}
+
+message RationaleEntry {
+  string option = 1;
+  double score = 2;
+  string why = 3;
+}
+
+message PlanRequest {
+  Objective objective = 1;
+}
+
+message PlanResponse {
+  string id = 1;
+  Objective objective = 2;
+  repeated RationaleEntry rationale = 3;
+}
+
+message RunRequest {
+  string instrument_id = 1;
+  map<string, string> params = 2;
+}
+
+message RunStatus {
+  string run_id = 1;
+  string state = 2;
+  string message = 3;
+}
+
+message QCRequest {
+  repeated string items = 1;
+  string notes = 2;
+}
+
+message QCResponse {
+  string id = 1;
+  string outcome = 2;
+  repeated string negatives = 3;
+}
+
+service ExperimentService {
+  rpc Plan(PlanRequest) returns (PlanResponse);
+  rpc StartRun(RunRequest) returns (stream RunStatus);
+  rpc SubmitQC(QCRequest) returns (QCResponse);
+}

--- a/rust/service/src/config.rs
+++ b/rust/service/src/config.rs
@@ -1,0 +1,66 @@
+use clap::Parser;
+use secrecy::SecretString;
+use serde::Deserialize;
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct TelemetryConfig {
+    pub otlp_endpoint: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct HttpConfig {
+    pub addr: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct GrpcConfig {
+    pub addr: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct DatabaseConfig {
+    pub url: Option<SecretString>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Settings {
+    pub http: HttpConfig,
+    pub grpc: GrpcConfig,
+    pub telemetry: TelemetryConfig,
+    pub database: DatabaseConfig,
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Self {
+            http: HttpConfig {
+                addr: "0.0.0.0:8080".into(),
+            },
+            grpc: GrpcConfig {
+                addr: "0.0.0.0:50051".into(),
+            },
+            telemetry: TelemetryConfig {
+                otlp_endpoint: None,
+            },
+            database: DatabaseConfig { url: None },
+        }
+    }
+}
+
+#[derive(Parser, Debug)]
+#[command(author, version, about = "Experiment service")]
+pub struct Cli {
+    #[arg(long, env = "SERVICE_CONFIG", default_value = "configs/service.yaml")]
+    pub config: PathBuf,
+}
+
+impl Settings {
+    pub fn load(cli: &Cli) -> anyhow::Result<Self> {
+        let mut settings = config::Config::builder()
+            .add_source(config::File::with_name(&cli.config.display().to_string()).required(false))
+            .add_source(config::Environment::with_prefix("SERVICE").separator("__"))
+            .build()?;
+        settings.try_deserialize().map_err(Into::into)
+    }
+}

--- a/rust/service/src/grpc.rs
+++ b/rust/service/src/grpc.rs
@@ -1,0 +1,128 @@
+use crate::AppState;
+use indexmap::IndexMap;
+use periodic_core::Objective;
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
+use tonic::{Request, Response, Status};
+use tracing::info_span;
+use uuid::Uuid;
+
+pub mod proto {
+    tonic::include_proto!("periodic");
+}
+
+use proto::experiment_service_server::{ExperimentService, ExperimentServiceServer};
+use proto::{PlanRequest, PlanResponse, QCRequest, QCResponse, RunRequest, RunStatus};
+
+#[derive(Clone)]
+pub struct ExperimentGrpc {
+    state: AppState,
+}
+
+impl ExperimentGrpc {
+    pub fn new(state: AppState) -> Self {
+        Self { state }
+    }
+}
+
+#[tonic::async_trait]
+impl ExperimentService for ExperimentGrpc {
+    type StartRunStream = ReceiverStream<Result<RunStatus, Status>>;
+
+    async fn plan(&self, request: Request<PlanRequest>) -> Result<Response<PlanResponse>, Status> {
+        let span = info_span!("grpc.plan");
+        let _guard = span.enter();
+        let payload = request.into_inner();
+        let mut metrics = IndexMap::new();
+        for metric in payload
+            .objective
+            .as_ref()
+            .map(|o| o.metrics.clone())
+            .unwrap_or_default()
+        {
+            metrics.insert(metric.name, metric.target);
+        }
+        let objective = Objective {
+            description: payload
+                .objective
+                .as_ref()
+                .map(|o| o.description.clone())
+                .unwrap_or_default(),
+            target_metrics: metrics,
+        };
+        let plan = self
+            .state
+            .planner
+            .plan(objective)
+            .map_err(|e| Status::internal(e.to_string()))?;
+        let response = PlanResponse {
+            id: plan.id.to_string(),
+            objective: Some(proto::Objective {
+                description: plan.objective.description,
+                metrics: plan
+                    .objective
+                    .target_metrics
+                    .into_iter()
+                    .map(|(name, target)| proto::ObjectiveMetric { name, target })
+                    .collect(),
+            }),
+            rationale: plan
+                .rationale_trace
+                .into_iter()
+                .map(|entry| proto::RationaleEntry {
+                    option: entry.option,
+                    score: entry.score,
+                    why: entry.why,
+                })
+                .collect(),
+        };
+        Ok(Response::new(response))
+    }
+
+    async fn start_run(
+        &self,
+        request: Request<RunRequest>,
+    ) -> Result<Response<Self::StartRunStream>, Status> {
+        let payload = request.into_inner();
+        let id = Uuid::new_v4();
+        self.state
+            .repository
+            .record_run(id, &payload.instrument_id)
+            .map_err(|err| Status::internal(err.to_string()))?;
+        let (tx, rx) = mpsc::channel(4);
+        let status = RunStatus {
+            run_id: id.to_string(),
+            state: "started".into(),
+            message: "Run accepted".into(),
+        };
+        tx.send(Ok(status)).await.unwrap();
+        Ok(Response::new(ReceiverStream::new(rx)))
+    }
+
+    async fn submit_qc(&self, request: Request<QCRequest>) -> Result<Response<QCResponse>, Status> {
+        let payload = request.into_inner();
+        let checklist = periodic_core::qc::checklist::Checklist {
+            id: Uuid::new_v4(),
+            name: "grpc".to_string(),
+            items: payload
+                .items
+                .into_iter()
+                .map(|item| periodic_core::qc::checklist::ChecklistItem {
+                    description: item,
+                    required: true,
+                    satisfied: true,
+                })
+                .collect(),
+        };
+        let qc = checklist
+            .run(payload.notes, vec![])
+            .map_err(|err| Status::internal(err.to_string()))?;
+        Ok(Response::new(QCResponse {
+            id: qc.id.to_string(),
+            outcome: format!("{:?}", qc.outcome),
+            negatives: qc.negatives_captured,
+        }))
+    }
+}
+
+pub use proto::experiment_service_server::ExperimentServiceServer;

--- a/rust/service/src/http.rs
+++ b/rust/service/src/http.rs
@@ -1,0 +1,198 @@
+use crate::AppState;
+use axum::{extract::State, response::IntoResponse, routing::post, Json, Router};
+use periodic_core::Objective;
+use prometheus::Encoder;
+use serde::{Deserialize, Serialize};
+use tracing::{info_span, Instrument};
+use utoipa::{OpenApi, ToSchema};
+use uuid::Uuid;
+
+#[derive(OpenApi)]
+#[openapi(
+    paths(plan, submit_qc, start_run),
+    components(schemas(PlanRequest, PlanResponse, ObjectiveDto, MetricDto, RationaleEntryDto, QCRequest, QCResponse)),
+    tags((name = "periodic", description = "Planning APIs"))
+)]
+pub struct ApiDoc;
+
+#[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
+pub struct MetricDto {
+    pub name: String,
+    pub target: f64,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
+pub struct ObjectiveDto {
+    pub description: String,
+    pub metrics: Vec<MetricDto>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
+pub struct PlanRequest {
+    pub objective: ObjectiveDto,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
+pub struct PlanResponse {
+    pub id: String,
+    pub objective: ObjectiveDto,
+    pub rationale: Vec<RationaleEntryDto>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
+pub struct RationaleEntryDto {
+    pub option: String,
+    pub score: f64,
+    pub why: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
+pub struct RunRequest {
+    pub instrument_id: String,
+    pub params: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
+pub struct RunEventDto {
+    pub run_id: String,
+    pub state: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
+pub struct QCRequest {
+    pub items: Vec<String>,
+    pub notes: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
+pub struct QCResponse {
+    pub id: String,
+    pub outcome: String,
+    pub negatives: Vec<String>,
+}
+
+pub fn build_routes(state: AppState) -> Router {
+    Router::new()
+        .route("/v1/plan", post(plan))
+        .route("/v1/run", post(start_run))
+        .route("/v1/qc", post(submit_qc))
+        .route("/docs", axum::routing::get(serve_docs))
+        .route("/docs/openapi.json", axum::routing::get(openapi_json))
+        .with_state(state)
+}
+
+#[utoipa::path(post, path = "/v1/plan", request_body = PlanRequest, responses((status = 200, body = PlanResponse)))]
+pub async fn plan(
+    State(state): State<AppState>,
+    Json(payload): Json<PlanRequest>,
+) -> Result<Json<PlanResponse>, axum::http::StatusCode> {
+    let span = info_span!("http.plan", objective = %payload.objective.description);
+    async move {
+        let planner = &state.planner;
+        let objective = Objective {
+            description: payload.objective.description.clone(),
+            target_metrics: payload
+                .objective
+                .metrics
+                .iter()
+                .map(|m| (m.name.clone(), m.target))
+                .collect(),
+        };
+        let plan = planner
+            .plan(objective)
+            .map_err(|_| axum::http::StatusCode::BAD_REQUEST)?;
+        Ok(Json(PlanResponse {
+            id: plan.id.to_string(),
+            objective: payload.objective,
+            rationale: plan
+                .rationale_trace
+                .into_iter()
+                .map(|entry| RationaleEntryDto {
+                    option: entry.option,
+                    score: entry.score,
+                    why: entry.why,
+                })
+                .collect(),
+        }))
+    }
+    .instrument(span)
+    .await
+}
+
+#[utoipa::path(post, path = "/v1/qc", request_body = QCRequest, responses((status = 200, body = QCResponse)))]
+pub async fn submit_qc(
+    State(state): State<AppState>,
+    Json(payload): Json<QCRequest>,
+) -> Result<Json<QCResponse>, axum::http::StatusCode> {
+    let checklist = periodic_core::qc::checklist::Checklist {
+        id: Uuid::new_v4(),
+        name: "http".to_string(),
+        items: payload
+            .items
+            .iter()
+            .map(|item| periodic_core::qc::checklist::ChecklistItem {
+                description: item.clone(),
+                required: true,
+                satisfied: true,
+            })
+            .collect(),
+    };
+    let qc = checklist
+        .run(payload.notes.clone(), vec![])
+        .map_err(|_| axum::http::StatusCode::INTERNAL_SERVER_ERROR)?;
+    Ok(Json(QCResponse {
+        id: qc.id.to_string(),
+        outcome: format!("{:?}", qc.outcome),
+        negatives: qc.negatives_captured,
+    }))
+}
+
+#[utoipa::path(post, path = "/v1/run", request_body = RunRequest, responses((status = 200)))]
+pub async fn start_run(
+    State(state): State<AppState>,
+    Json(payload): Json<RunRequest>,
+) -> Result<Json<RunEventDto>, axum::http::StatusCode> {
+    let id = Uuid::new_v4();
+    state
+        .repository
+        .record_run(id, &payload.instrument_id)
+        .map_err(|_| axum::http::StatusCode::INTERNAL_SERVER_ERROR)?;
+    Ok(Json(RunEventDto {
+        run_id: id.to_string(),
+        state: "started".to_string(),
+        message: "Run accepted".to_string(),
+    }))
+}
+
+pub async fn serve_docs() -> impl IntoResponse {
+    axum::response::Html(utoipa_swagger_ui::SwaggerUi::new("/docs/openapi.json").to_html())
+}
+
+pub async fn openapi_json() -> impl IntoResponse {
+    Json(ApiDoc::openapi())
+}
+
+pub async fn healthz() -> &'static str {
+    "ok"
+}
+
+pub async fn readyz() -> &'static str {
+    "ready"
+}
+
+pub async fn metrics_handler(State(state): State<AppState>) -> impl IntoResponse {
+    let metrics = state
+        .exporter
+        .registry()
+        .gather()
+        .into_iter()
+        .map(prometheus::proto::MetricFamily::to_owned)
+        .collect::<Vec<_>>();
+    let mut buffer = vec![];
+    let encoder = prometheus::TextEncoder::new();
+    encoder
+        .encode(&metrics, &mut buffer)
+        .expect("encode metrics");
+    (axum::http::StatusCode::OK, buffer)
+}

--- a/rust/service/src/lib.rs
+++ b/rust/service/src/lib.rs
@@ -1,0 +1,50 @@
+pub mod config;
+pub mod grpc;
+pub mod http;
+pub mod repo;
+pub mod telemetry;
+
+use axum::{routing::get, Router};
+use opentelemetry_prometheus::PrometheusExporter;
+use periodic_core::CorePlanner;
+use std::sync::Arc;
+use tonic::transport::Server;
+use tracing::info;
+
+pub type SharedPlanner = Arc<CorePlanner>;
+
+#[derive(Clone)]
+pub struct AppState {
+    pub planner: SharedPlanner,
+    pub repository: repo::InMemoryRepository,
+    pub exporter: Arc<PrometheusExporter>,
+}
+
+impl AppState {
+    pub fn new(planner: SharedPlanner, exporter: PrometheusExporter) -> Self {
+        Self {
+            planner,
+            repository: repo::InMemoryRepository::default(),
+            exporter: Arc::new(exporter),
+        }
+    }
+}
+
+pub fn build_http_router(state: AppState) -> Router {
+    Router::new()
+        .merge(http::build_routes(state.clone()))
+        .route("/healthz", get(http::healthz))
+        .route("/readyz", get(http::readyz))
+        .route("/metrics", get(http::metrics_handler))
+        .with_state(state)
+}
+
+pub async fn serve_grpc(state: AppState, addr: std::net::SocketAddr) -> anyhow::Result<()> {
+    let svc = grpc::ExperimentGrpc::new(state);
+    info!("starting grpc", %addr);
+    Server::builder()
+        .add_service(grpc::ExperimentServiceServer::new(svc))
+        .serve(addr)
+        .await?;
+    Ok(())
+}

--- a/rust/service/src/main.rs
+++ b/rust/service/src/main.rs
@@ -1,0 +1,71 @@
+use clap::Parser;
+use service::{
+    build_http_router,
+    config::{Cli, Settings},
+    serve_grpc, telemetry, AppState,
+};
+use std::sync::Arc;
+use tokio::signal;
+use tracing::{info, warn};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+    let settings = Settings::load(&cli).unwrap_or_default();
+
+    let exporter = telemetry::init_tracing("periodic-service", &settings.telemetry);
+    let planner = periodic_core::CorePlanner::new(42);
+    let state = AppState::new(Arc::new(planner), exporter);
+
+    let http_addr: std::net::SocketAddr = settings.http.addr.parse()?;
+    let grpc_addr: std::net::SocketAddr = settings.grpc.addr.parse()?;
+
+    let app = build_http_router(state.clone());
+    let http_server = axum::Server::bind(&http_addr).serve(app.into_make_service());
+
+    let grpc_state = state.clone();
+    let grpc_future = serve_grpc(grpc_state, grpc_addr);
+
+    info!("service starting", %http_addr, %grpc_addr);
+
+    tokio::select! {
+        result = http_server => {
+            if let Err(err) = result {
+                warn!(?err, "http server failed");
+            }
+        }
+        result = grpc_future => {
+            if let Err(err) = result {
+                warn!(?err, "grpc server failed");
+            }
+        }
+        _ = shutdown_signal() => {
+            info!("shutdown signal received");
+        }
+    }
+
+    telemetry::shutdown();
+    Ok(())
+}
+
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        signal::ctrl_c()
+            .await
+            .expect("failed to install CTRL+C handler");
+    };
+    #[cfg(unix)]
+    let terminate = async {
+        signal::unix::signal(signal::unix::SignalKind::terminate())
+            .expect("install signal")
+            .recv()
+            .await;
+    };
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        _ = ctrl_c => {},
+        _ = terminate => {},
+    }
+}

--- a/rust/service/src/repo.rs
+++ b/rust/service/src/repo.rs
@@ -1,0 +1,65 @@
+use anyhow::Result;
+use chrono::Utc;
+use futures::executor;
+use indexmap::IndexMap;
+use periodic_core::Run;
+use std::{collections::HashMap, sync::Arc};
+use tokio::sync::RwLock;
+use uuid::Uuid;
+
+#[async_trait::async_trait]
+pub trait RunRepository: Send + Sync {
+    async fn record_run(&self, run: Run) -> Result<()>;
+    async fn latest(&self) -> Result<Option<Run>>;
+}
+
+#[derive(Default, Clone)]
+pub struct InMemoryRepository {
+    inner: Arc<RwLock<HashMap<Uuid, Run>>>,
+}
+
+impl InMemoryRepository {
+    pub fn record_run(&self, id: Uuid, instrument: &str) -> Result<()> {
+        let mut guard = executor::block_on(self.inner.write());
+        guard.insert(
+            id,
+            Run {
+                id,
+                instrument_id: instrument.to_string(),
+                params: IndexMap::new(),
+                started_at: Utc::now(),
+                finished_at: None,
+                artifacts: vec![],
+            },
+        );
+        Ok(())
+    }
+}
+
+#[cfg(feature = "postgres")]
+pub mod postgres {
+    use super::*;
+    use sqlx::PgPool;
+
+    #[derive(Clone)]
+    pub struct PostgresRepository {
+        pool: PgPool,
+    }
+
+    impl PostgresRepository {
+        pub fn new(pool: PgPool) -> Self {
+            Self { pool }
+        }
+
+        pub async fn record_run(&self, id: Uuid, instrument: &str) -> Result<()> {
+            sqlx::query!(
+                "INSERT INTO runs (id, instrument_id) VALUES ($1, $2)",
+                id,
+                instrument
+            )
+            .execute(&self.pool)
+            .await?;
+            Ok(())
+        }
+    }
+}

--- a/rust/service/src/telemetry.rs
+++ b/rust/service/src/telemetry.rs
@@ -1,0 +1,40 @@
+use opentelemetry::global;
+use opentelemetry_otlp::WithExportConfig;
+use opentelemetry_prometheus::PrometheusExporter;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+use crate::config::TelemetryConfig;
+
+pub fn init_tracing(service_name: &str, telemetry: &TelemetryConfig) -> PrometheusExporter {
+    let exporter = opentelemetry_prometheus::exporter().init();
+
+    let tracer = if let Some(endpoint) = &telemetry.otlp_endpoint {
+        let otlp_exporter = opentelemetry_otlp::new_exporter()
+            .tonic()
+            .with_endpoint(endpoint);
+        let trace_exporter = opentelemetry_otlp::new_pipeline()
+            .tracing()
+            .with_exporter(otlp_exporter)
+            .install_batch(opentelemetry::runtime::Tokio)
+            .expect("otlp");
+        trace_exporter
+    } else {
+        opentelemetry::sdk::trace::TracerProvider::builder()
+            .with_simple_exporter(opentelemetry_stdout::SpanExporter::default())
+            .build()
+            .tracer(service_name)
+    };
+
+    let otel_layer = tracing_opentelemetry::layer().with_tracer(tracer);
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::EnvFilter::from_default_env())
+        .with(tracing_subscriber::fmt::layer().json())
+        .with(otel_layer)
+        .init();
+
+    exporter
+}
+
+pub fn shutdown() {
+    global::shutdown_tracer_provider();
+}

--- a/rust/service/tests/integration_grpc.rs
+++ b/rust/service/tests/integration_grpc.rs
@@ -1,0 +1,22 @@
+use opentelemetry_prometheus::exporter;
+use service::{grpc::ExperimentGrpc, AppState};
+use std::sync::Arc;
+use tonic::Request;
+
+#[tokio::test]
+async fn grpc_plan_returns_plan() {
+    let exporter = exporter().init();
+    let state = AppState::new(Arc::new(periodic_core::CorePlanner::new(2)), exporter);
+    let grpc = ExperimentGrpc::new(state);
+    let request = tonic::Request::new(service::grpc::proto::PlanRequest {
+        objective: Some(service::grpc::proto::Objective {
+            description: "test".into(),
+            metrics: vec![service::grpc::proto::ObjectiveMetric {
+                name: "yield".into(),
+                target: 0.9,
+            }],
+        }),
+    });
+    let response = grpc.plan(request).await.unwrap().into_inner();
+    assert_eq!(response.objective.unwrap().description, "test");
+}

--- a/rust/service/tests/integration_http.rs
+++ b/rust/service/tests/integration_http.rs
@@ -1,0 +1,28 @@
+use opentelemetry_prometheus::exporter;
+use service::{build_http_router, AppState};
+use std::sync::Arc;
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn plan_endpoint_returns_plan() {
+    let _ = tracing_subscriber::fmt::try_init();
+    let exporter = exporter().init();
+    let state = AppState::new(Arc::new(periodic_core::CorePlanner::new(1)), exporter);
+    let app = build_http_router(state);
+    let body = serde_json::json!({
+        "objective": {
+            "description": "test",
+            "metrics": [{"name": "yield", "target": 0.8}]
+        }
+    });
+    let response = app
+        .oneshot(
+            http::Request::post("/v1/plan")
+                .header(http::header::CONTENT_TYPE, "application/json")
+                .body(axum::body::Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert!(response.status().is_success());
+}

--- a/rust/wasm-demo/Cargo.toml
+++ b/rust/wasm-demo/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "wasm-demo"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+periodic_core = { path = "../core", package = "core", features = ["wasm"] }
+wasm-bindgen.workspace = true
+wasm-bindgen-futures.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+console_error_panic_hook = { version = "0.1", optional = true }
+js-sys.workspace = true
+web-sys.workspace = true
+getrandom.workspace = true
+
+[features]
+default = []
+console = ["console_error_panic_hook"]

--- a/rust/wasm-demo/index.html
+++ b/rust/wasm-demo/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Periodic Experiment Planner</title>
+    <script type="module">
+      import init, { PlannerHandle } from "./pkg/wasm_demo.js";
+      async function run() {
+        await init();
+        const planner = new PlannerHandle(7);
+        const objective = {
+          description: "Rapid catalyst screening",
+          metrics: [{ name: "yield", target: 0.88 }]
+        };
+        const plan = planner.plan(objective);
+        document.getElementById("output").textContent = JSON.stringify(plan, null, 2);
+      }
+      run();
+    </script>
+  </head>
+  <body>
+    <h1>Experiment Planner</h1>
+    <pre id="output">Loading...</pre>
+  </body>
+</html>

--- a/rust/wasm-demo/src/lib.rs
+++ b/rust/wasm-demo/src/lib.rs
@@ -1,0 +1,48 @@
+use indexmap::IndexMap;
+use periodic_core::{CorePlanner, Objective};
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub struct PlannerHandle {
+    inner: CorePlanner,
+}
+
+#[wasm_bindgen]
+impl PlannerHandle {
+    #[wasm_bindgen(constructor)]
+    pub fn new(seed: u64) -> PlannerHandle {
+        #[cfg(feature = "console")]
+        console_error_panic_hook::set_once();
+        PlannerHandle {
+            inner: CorePlanner::new(seed),
+        }
+    }
+
+    #[wasm_bindgen]
+    pub fn plan(&self, objective: JsValue) -> Result<JsValue, JsValue> {
+        let value: serde_json::Value = objective.into_serde().map_err(|e| e.to_string())?;
+        let description = value
+            .get("description")
+            .and_then(|d| d.as_str())
+            .unwrap_or_default()
+            .to_string();
+        let mut metrics = IndexMap::new();
+        if let Some(entries) = value.get("metrics").and_then(|m| m.as_array()) {
+            for entry in entries {
+                if let (Some(name), Some(target)) = (entry.get("name"), entry.get("target")) {
+                    if let (Some(name), Some(target)) = (name.as_str(), target.as_f64()) {
+                        metrics.insert(name.to_string(), target);
+                    }
+                }
+            }
+        }
+        let plan = self
+            .inner
+            .plan(Objective {
+                description,
+                target_metrics: metrics,
+            })
+            .map_err(|e| e.to_string())?;
+        JsValue::from_serde(&plan).map_err(|e| e.to_string().into())
+    }
+}


### PR DESCRIPTION
## Summary
- add a Rust workspace with core domain logic, HTTP/gRPC service, Python bindings, and a WASM demo
- wire tracing, OpenTelemetry, SQLx-ready repositories, fuzz/property tests, and feature flags across crates
- document setup and developer workflows with a Justfile, configs, and README updates

## Testing
- not run (dependency downloads blocked in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dda0cc2ba88331b865d228f92dc46c