### PR TITLE
fix(ci): Remove invalid python-version from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Core Python dependencies
-python-version==3.12
+# Python 3.12+ required (specified in workflow, not as a package)
 
 # Web Framework
 fastapi==0.104.1


### PR DESCRIPTION
## Critical Bug Fix for CI/CD Pipeline

### Problem
All GitHub Actions workflows are failing with:
```
ERROR: No matching distribution found for python-version==3.12
```

### Root Cause
- Line 2 of `requirements.txt` contained: `python-version==3.12`
- This is **not a valid Python package** - it's a workflow YAML setting
- `pip install` fails when trying to install this non-existent package

### Solution
- ✅ Removed the invalid line from `requirements.txt`
- ✅ Added a comment explaining Python version is specified in the workflow file
- ✅ No functional changes to the application

### Impact
- **Fixes**: All failing GitHub Actions workflows
- **Unblocks**: CI/CD pipeline
- **Tested**: Already validated on branch `feat-api-security-d53b7` (commit e927a66)

### Files Changed
- `requirements.txt`: Removed `python-version==3.12` (line 2)

### Urgency
**HIGH** - This blocks all CI/CD operations. Merge ASAP to restore automated testing and deployment.

---
**Related Branch**: feat-api-security-d53b7 has the same fix applied