### PR TITLE
Ensure coverage XML is generated in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,11 @@ jobs:
           DATABASE_URL: sqlite:///$(pwd)/ci-telemetry.db
         run: |
           pytest --cov-report=xml --cov-report=term-missing
+      - name: Ensure coverage XML exists
+        run: |
+          if [ ! -f coverage.xml ]; then
+            coverage xml -i
+          fi
       - name: Enforce coverage minimum
         run: |
           python - <<'PY'


### PR DESCRIPTION
## Summary
- add a guard step in the CI workflow to generate coverage.xml when pytest does not create it automatically

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68e34315f3a48331af2ff9ae9d8b907e